### PR TITLE
Add better error message when command is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ arguments = csharpier {file}
 
 The following options are supported:
 
-- **command** - the command to run. It should be either fully qualified or available on the Path environment variable.
+- **command** - the command to run. It should be either fully qualified or available on the Path environment variable. For `.cmd` and `.bat` files, make sure the file extension is included in the command.
 - **arguments** - the arguments to supply to the command. It supports the following placeholders:
   - `{file}` - The fully qualifed file that was saved (e.g. C:\Foo\Bar.cs)
   - `{filename}` - The file name only (e.g. Bar.cs)

--- a/RunOnSave.Tests/TextViewCreationListenerTests.cs
+++ b/RunOnSave.Tests/TextViewCreationListenerTests.cs
@@ -78,7 +78,7 @@ namespace RunOnSave.Tests
         }
 
         [TestMethod]
-        public void TextViewCreationListener_IgnoredFileOpenedAndSaves_DoesNotRunsProcess()
+        public void TextViewCreationListener_IgnoredFileOpenedAndSaves_DoesNotRunProcess()
         {
             const string OpenedFile = @"C:\repos\Foo.cs";
 

--- a/RunOnSave/source.extension.vsixmanifest
+++ b/RunOnSave/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="RunOnSave.7de8e627-4e33-4425-84ba-cc028ada1ca0" Version="1.0" Language="en-US" Publisher="Will Fuqua" />
+        <Identity Id="RunOnSave.7de8e627-4e33-4425-84ba-cc028ada1ca0" Version="1.1" Language="en-US" Publisher="Will Fuqua" />
         <DisplayName>RunOnSave</DisplayName>
         <Description xml:space="preserve">A Visual Studio extension that can run commands on files when they're saved. Configured using an .onsaveconfig file, which can be checked into version control.</Description>
         <MoreInfo>https://github.com/waf/RunOnSave/</MoreInfo>


### PR DESCRIPTION
Rather than log an exception when the command isn't found, handle it more gracefully and provide some suggestions on how the user can fix it.

Fixes #1