### PR TITLE
VS2019 compatibility

### DIFF
--- a/RunOnSave.Tests/RunOnSave.Tests.csproj
+++ b/RunOnSave.Tests/RunOnSave.Tests.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.0-previews-4-31709-430</Version>
+      <Version>16.10.31321.278</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.0.5232</Version>

--- a/RunOnSave/RunOnSave.csproj
+++ b/RunOnSave/RunOnSave.csproj
@@ -67,8 +67,13 @@
     <PackageReference Include="editorconfig">
       <Version>0.12.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-4-31709-430" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\RunOnSaveLogo.png">

--- a/RunOnSave/source.extension.vsixmanifest
+++ b/RunOnSave/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="RunOnSave.7de8e627-4e33-4425-84ba-cc028ada1ca0" Version="1.1" Language="en-US" Publisher="Will Fuqua" />
+        <Identity Id="RunOnSave.7de8e627-4e33-4425-84ba-cc028ada1ca0" Version="1.2" Language="en-US" Publisher="Will Fuqua" />
         <DisplayName>RunOnSave</DisplayName>
         <Description xml:space="preserve">A Visual Studio extension that can run commands on files when they're saved. Configured using an .onsaveconfig file, which can be checked into version control.</Description>
         <MoreInfo>https://github.com/waf/RunOnSave/</MoreInfo>
@@ -19,13 +19,13 @@
         <InstallationTarget Version="[17.0, 18.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,16.0)" Id="Microsoft.VisualStudio.Community">
+        <InstallationTarget Version="16.0" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,16.0)" Id="Microsoft.VisualStudio.Pro">
+        <InstallationTarget Version="16.0" Id="Microsoft.VisualStudio.Pro">
             <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[16.0,16.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <InstallationTarget Version="16.0" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>x86</ProductArchitecture>
         </InstallationTarget>
     </Installation>
@@ -33,7 +33,7 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Only VS2022 was supported; this increases the compatibility range for VS 2019.

Microsoft.VisualStudio.SDK needs to target v16, but build tools need to remain at v17 so it can take advantage of new schema elements in VS2022.

Closes #3 