### PR TITLE
Add a new aways_run configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following options are supported:
   - `{directory}` - The directory only (e.g. C:\Foo)
 - **working_directory** - The working directory to run the command in. Defaults to the directory of the file that was saved.
 - **timeout_seconds** - How long to wait for the command to finish. Defaults to 30 seconds.
+- **always_run** - by default, RunOnSave only runs the command when the input file has changed (so repeatedly pressing ctrl-s will only call the command once). Set this to `true` to disable this behavior, so the command will always run. This may be required if you have additional extensions that also modify the file on save.
 
 Similar to `.editorconfig`, specific files can be ignored by setting the command to `unset` or `ignore`:
 

--- a/RunOnSave/CommandTemplate.cs
+++ b/RunOnSave/CommandTemplate.cs
@@ -19,6 +19,7 @@ namespace RunOnSave
         private const string ArgumentsKey = "arguments";
         private const string WorkingDirectoryKey = "working_directory";
         private const string TimeoutKey = "timeout_seconds";
+        private const string AlwaysRunKey = "always_run";
 
         private readonly IReadOnlyList<string> ignoreValues = new[] { "ignore", "unset" };
 
@@ -50,6 +51,8 @@ namespace RunOnSave
         /// </summary>
         public bool ShouldIgnore => string.IsNullOrWhiteSpace(Command)
             || ignoreValues.Contains(Command, StringComparer.OrdinalIgnoreCase);
+
+        public bool AlwaysRun { get; private set; } = false;
 
         /// <summary>
         /// Fills in the current CommandTemplate, creating a ProcessStartInfo.
@@ -100,6 +103,12 @@ namespace RunOnSave
             if (configuration.TryGetValue(WorkingDirectoryKey, out string workingDirectory))
             {
                 config.WorkingDirectory = workingDirectory;
+            }
+
+            if (configuration.TryGetValue(AlwaysRunKey, out string alwaysRunValue)
+                && bool.TryParse(alwaysRunValue, out bool alwaysRun))
+            {
+                config.AlwaysRun = alwaysRun;
             }
 
             if (configuration.TryGetValue(TimeoutKey, out string timeout)

--- a/RunOnSave/Logger.cs
+++ b/RunOnSave/Logger.cs
@@ -24,32 +24,43 @@ namespace RunOnSave
             if (string.IsNullOrEmpty(message))
                 return;
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            try
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                try
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    if (_pane == null)
-                    {
-                        Guid guid = Guid.NewGuid();
-                        if(_output != null)
-                        {
-                            _output.CreatePane(ref guid, _name, 1, 1);
-                            _output.GetPane(ref guid, out _pane);
-                        }
-                    }
-
-                    _pane?.OutputStringThreadSafe(message + Environment.NewLine);
-                }
-                catch
-                {
-                    // Do nothing
-                }
-            });
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    LogToOutputWindow(message);
+                });
+            }
+            catch
+            {
+                // this only throws in unit tests where the threading model is different.
+            }
         }
 
         public static void Log(Exception ex) =>
             Log("Exception: " + ex.ToString());
+
+        private static void LogToOutputWindow(string message)
+        {
+            try
+            {
+                if (_pane == null)
+                {
+                    Guid guid = Guid.NewGuid();
+                    if (_output != null)
+                    {
+                        _output.CreatePane(ref guid, _name, 1, 1);
+                        _output.GetPane(ref guid, out _pane);
+                    }
+                }
+
+                _pane?.OutputStringThreadSafe(message + Environment.NewLine);
+            }
+            catch
+            {
+                // Do nothing
+            }
+        }
     }
 }

--- a/RunOnSave/RunOnSave.csproj
+++ b/RunOnSave/RunOnSave.csproj
@@ -70,7 +70,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/RunOnSave/TextViewCreationListener.cs
+++ b/RunOnSave/TextViewCreationListener.cs
@@ -92,7 +92,7 @@ namespace RunOnSave
             if (!this.command.AlwaysRun &&
                 previousSnapshot == this.document.TextBuffer.CurrentSnapshot)
             {
-                Logger.Log("Skipping command -- file not changed");
+                Logger.Log("Skipping command because the file is not changed. Configure \"always_run\" to change this behavior.");
                 return;
             }
 

--- a/RunOnSave/TextViewCreationListener.cs
+++ b/RunOnSave/TextViewCreationListener.cs
@@ -64,12 +64,11 @@ namespace RunOnSave
                 this.command = cmd;
                 this.document.FileActionOccurred += DocumentSaved;
             });
-
         }
 
         private void TextViewClosed(object sender, EventArgs e)
         {
-            if(this.document != null)
+            if (this.document != null)
             {
                 this.document.FileActionOccurred -= DocumentSaved;
             }
@@ -89,10 +88,11 @@ namespace RunOnSave
             if (string.IsNullOrEmpty(e.FilePath) || !Path.IsPathRooted(e.FilePath))
                 return;
 
-            // don't bother reformatting if the file hasn't been changed.
-            if (previousSnapshot == this.document.TextBuffer.CurrentSnapshot)
+            // don't call the command if the file hasn't changed, unless always_run is specified by user.
+            if (!this.command.AlwaysRun &&
+                previousSnapshot == this.document.TextBuffer.CurrentSnapshot)
             {
-                Logger.Log("Skipping formatting -- file not changed");
+                Logger.Log("Skipping command -- file not changed");
                 return;
             }
 

--- a/RunOnSave/source.extension.vsixmanifest
+++ b/RunOnSave/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="RunOnSave.7de8e627-4e33-4425-84ba-cc028ada1ca0" Version="1.2" Language="en-US" Publisher="Will Fuqua" />
+        <Identity Id="RunOnSave.7de8e627-4e33-4425-84ba-cc028ada1ca0" Version="1.3" Language="en-US" Publisher="Will Fuqua" />
         <DisplayName>RunOnSave</DisplayName>
         <Description xml:space="preserve">A Visual Studio extension that can run commands on files when they're saved. Configured using an .onsaveconfig file, which can be checked into version control.</Description>
         <MoreInfo>https://github.com/waf/RunOnSave/</MoreInfo>


### PR DESCRIPTION
Adds a new `always_run` configuration option, to disable the "only run when file has changed" default behavior of RunOnSave

Fixes #6

Sample usage:

```ini
[*.cs]
command = dotnet
arguments = csharpier {file}
always_run = true
```