### PR TITLE
Support solution-relative placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ The following options are supported:
 
 - **command** - the command to run. It should be either fully qualified or available on the Path environment variable. For `.cmd` and `.bat` files, make sure the file extension is included in the command.
 - **arguments** - the arguments to supply to the command. It supports the following placeholders:
-  - `{file}` - The fully qualifed file that was saved (e.g. C:\Foo\Bar.cs)
-  - `{filename}` - The file name only (e.g. Bar.cs)
-  - `{directory}` - The directory only (e.g. C:\Foo)
+  - `{file}` - The file that was saved, fully qualified (e.g. C:\MySolution\MyProject\Program.cs)
+  - `{file_in_solution}` - The file that was saved, relative to the solution_directory (e.g. MyProject\Program.cs)
+  - `{filename}` - The file name of the file that was saved (e.g. Program.cs)
+  - `{directory}` - The directory containing the file that was saved (e.g. C:\MySolution\MyProject)
+  - `{solution_directory}` - The directory of the solution file (e.g. C:\MySolution)
 - **working_directory** - The working directory to run the command in. Defaults to the directory of the file that was saved.
 - **timeout_seconds** - How long to wait for the command to finish. Defaults to 30 seconds.
 - **always_run** - by default, RunOnSave only runs the command when the input file has changed (so repeatedly pressing ctrl-s will only call the command once). Set this to `true` to disable this behavior, so the command will always run. This may be required if you have additional extensions that also modify the file on save.

--- a/RunOnSave/CommandTemplate.cs
+++ b/RunOnSave/CommandTemplate.cs
@@ -66,7 +66,9 @@ namespace RunOnSave
                 arguments = arguments
                     .Replace("{file}", filePath)
                     .Replace("{filename}", Path.GetFileName(filePath))
-                    .Replace("{directory}", Path.GetDirectoryName(filePath));
+                    .Replace("{directory}", Path.GetDirectoryName(filePath))
+                    .Replace("{file_in_solution}", MakePathRelativeToDirectory(filePath, Environment.CurrentDirectory))
+                    .Replace("{solution_directory}", Environment.CurrentDirectory);
             }
 
             return new ProcessStartInfo
@@ -79,6 +81,14 @@ namespace RunOnSave
                 RedirectStandardError = true,
                 WorkingDirectory = WorkingDirectory ?? Path.GetDirectoryName(filePath)
             };
+        }
+
+        private static string MakePathRelativeToDirectory(string filePath, string directory)
+        {
+            // directory must end in trailing slash for Uri.MakeRelativeUri to behave correctly
+            var directoryUri = new Uri(directory.Last() == Path.DirectorySeparatorChar ? directory : directory + Path.DirectorySeparatorChar);
+            var relativePath = directoryUri.MakeRelativeUri(new Uri(filePath)).ToString();
+            return Uri.UnescapeDataString(relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
         }
 
         /// <summary>

--- a/RunOnSave/RunOnSavePackage.cs
+++ b/RunOnSave/RunOnSavePackage.cs
@@ -34,7 +34,6 @@ namespace RunOnSave
         /// RunOnSavePackage GUID string.
         /// </summary>
         public const string PackageGuidString = "b6f7ec6a-e985-4805-9562-18af25cd2c81";
-        internal static EditorConfigParser Parser { get; set; }
 
         #region Package Members
 


### PR DESCRIPTION
Closes #8

Adds two new placeholder options:

  - `{solution_directory}` - The directory of the solution file (e.g. C:\MySolution)
  - `{file_in_solution}` - The file that was saved, relative to the solution_directory (e.g. MyProject\Program.cs)